### PR TITLE
Monitor

### DIFF
--- a/web/lang/en.menus.php
+++ b/web/lang/en.menus.php
@@ -24,7 +24,7 @@ addS ("menus_cloudy_system","System");
 addS ("menus_cloudy_updates","Updates");
 addS ("menus_cloudy_sshkeys","Add developers' SSH keys");
 addS ("menus_cloudy_logout","Log out");
-
+addS ("menus_cloudy_monitor","Monitor");
 
 //Getinconf
 addS ("menus_getinconf_getinconf","Getinconf");

--- a/web/plug/controllers/cloudyupdate.php
+++ b/web/plug/controllers/cloudyupdate.php
@@ -6,7 +6,8 @@
 $list_packages = array('cDistro'=>array('user'=>'Clommunity', 'repo'=>'cDistro','type'=>'manual','script'=>'https://raw.githubusercontent.com/Clommunity/lbmake/master/hooks/cDistro.chroot'),
 					   'avahi-ps'=>array('user'=>'Clommunity', 'repo'=>'avahi-ps','type'=>'manual','script'=>'https://raw.githubusercontent.com/Clommunity/lbmake/master/hooks/avahi-ps.chroot'),
 					   'serf'=>array('user'=>'Clommunity', 'repo'=>'package-serf','type'=>'manual','controller'=>'serf', 'script'=>'https://raw.githubusercontent.com/Clommunity/lbmake/master/hooks/serf.chroot'),
-					   'peerstreamer'=>array('user'=>'Clommunity', 'repo'=>'build-peerstreamer','type'=>'preinstall','controller'=>'peerstreamer', 'function-check'=>'_isInstalled', 'script'=>'https://raw.githubusercontent.com/Clommunity/lbmake/master/hooks/peerstreamer.chroot')
+					   'peerstreamer'=>array('user'=>'Clommunity', 'repo'=>'build-peerstreamer','type'=>'preinstall','controller'=>'peerstreamer', 'function-check'=>'_isInstalled', 'script'=>'https://raw.githubusercontent.com/Clommunity/lbmake/master/hooks/peerstreamer.chroot'),
+					   'monitor'=>array('user'=>'Clommunity', 'repo'=>'monitor','type'=>'auto','controller'=>'monitor-aas','script'=>'https://raw.githubusercontent.com/Clommunity/monitor/master/getgithub')
 			// 'peerstreamer'=>array('user'=>'Clommunity', 'repo'=>'build-peerstreamer','type'=>'manual','controller'=>'peerstreamer', 'script'=>'https://raw.githubusercontent.com/Clommunity/lbmake/master/hooks/peerstreamer.chroot')
 					   );
 $dir_configs="/etc/cloudy";

--- a/web/plug/controllers/monitor-aas.php
+++ b/web/plug/controllers/monitor-aas.php
@@ -1,0 +1,37 @@
+<?php
+//controllers/monitor-aas.php
+
+$urlpath="/monitor-aas";
+$install_script="https://raw.githubusercontent.com/Clommunity/monitor/master/getgithub";
+
+function index(){
+	global $urlpath, $staticFile;
+	
+	$page .= hlc(t("Monitor as a Service"));
+        $page .= hl(t("Monitor/Loggging extended service to Cloudy"),4);
+	$page .= "<div class='alert alert-error text-center'>".t("Monitor as a Service not installed yet")."</div>\n";
+	$page .= par(t("How to install?<br>Just click Install, and wait till it finishes. It will update Cloudy and services aces accordingly, and restart SERF."));
+	$page .= addButton(array('label'=>t("Install"),'class'=>'btn btn-success', 'href'=>"$staticFile$urlpath/install"));
+
+	return(array('type' => 'render','page' => $page));
+}
+
+function install() {
+	global $install_script,$staticFile,$urlpath;
+	//Just to make sure we get the install script error!
+	$cmd = "cd /tmp/ && mkdir monitor_inst && cd monitor_inst";
+	execute_program_shell($cmd)['output'];
+
+	$cmd = "cd /tmp/monitor_inst/ && curl -k  ".$install_script." | sh - 2>&1";
+	$ret = execute_program_shell($cmd)['output'];
+
+	$cmd = "cd /tmp ; rm -rf monitor_inst";
+	execute_program_shell($cmd)['output'];
+	
+	if (strpos($ret,"Not") !== false)
+                setFlash(t("Monitor Service Error, msg: ".$ret),"error");
+	else
+		setFlash(t("Monitor Service installed"),"success");
+
+	return(array('type'=>'redirect','url'=>$staticFile.$urlpath));
+}

--- a/web/plug/menus/cloudy.menu.php
+++ b/web/plug/menus/cloudy.menu.php
@@ -4,5 +4,6 @@ addMenu(t('menus_cloudy_updates'),'cloudyupdate',t('menus_cloudy_system'),'left'
 addMenu(t('menus_cloudy_settings'),'settings',t('menus_cloudy_system'),'left');
 addMenu(t('menus_cloudy_sshkeys'),'sshkeys',t('menus_cloudy_system'),'left');
 addMenu(t('menus_cloudy_ssl'),'ssl',t('menus_cloudy_system'),'left');
+addMenu(t('menus_cloudy_monitor'),'monitor-aas',t('menus_cloudy_system'),'left');
 addMenu(t('menus_cloudy_logout'),'logout',t('menus_cloudy_system'),'left');
 


### PR DESCRIPTION
The extra monitor/logging part can now be integrated into cloudy.
In cDistro: 
- New Menu Item for Monitor 
- In System->Updates a new service

for users to install the monitor service.

The actual installation will be done from https://github.com/Clommunity/monitor
like other services (using the **getgithub** script file).

As example, this is a docker container with Cloudy built with the branch monitor:
http://10.139.40.91:7500/

Issue:  
- services should be installed before monitor
- or wait 1day till **auto-update** of monitor occurs

The monitor only works for: **Peerstreamer**, **Tahoe-lafs** and **SyncThing**.
Other services will be added as needed.
