### PR TITLE
add backward compatible extension to json service description format

### DIFF
--- a/web/plug/controllers/docker-add.php
+++ b/web/plug/controllers/docker-add.php
@@ -367,7 +367,7 @@ function templates_table($ttype, $templatesdir)
             $fcontent = file_get_contents($templatesdir . '/' . $fvalue);
             $jcontent = json_decode($fcontent, true);
 
-            if ( isset($jcontent["arch"]) && $jcontent['arch'] == aptArch() ) {
+            if ( isset($jcontent["arch"]) && ($jcontent['arch'] == aptArch() || in_array(aptArch(), $jcontent['arch']))) {
                 $fields = "";
                 $fields[] = $jcontent["appname"];
                 $fields[] = $jcontent["description"];


### PR DESCRIPTION
The "arch" field of the service description can now be either a string or a string array.
This helps in supporting docker multi-platform image feature.

We use last docker feature [1] to enable our docker image to be multi-platform and allow image pulls to be seamless with respect the machine architecture. So the "arch" field is modified to represent an array rather than a single string value and to allow multiple platform to be expressed, e.g.:
 "arch": ["armhf", "amd64"]

[1]  https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/